### PR TITLE
Explain in readme to use v2 exports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 #fintech #nonprofit charity promoting zero commission donations and volunteering for charities.
 API is a working prototype. 80% of code is ready. Postman collection for API testing and front-end app development. Get Postman, import the collections and start testing.
 
+Export to V2 to update the collections when developing.
+
 ## API process description
 https://slides.com/yoquieroayudar-es/
 


### PR DESCRIPTION
We should now ONLY export to V2 while developing.